### PR TITLE
Fixed crash in stringToRainbow

### DIFF
--- a/src/main/java/com/tfar/extraanvils/generic/BlockGenericAnvil.java
+++ b/src/main/java/com/tfar/extraanvils/generic/BlockGenericAnvil.java
@@ -241,7 +241,7 @@ public class BlockGenericAnvil extends BlockFalling {
             };
     for (int i = 0; i < stringLength; i++)
     {
-      outputString.append(colorChar[(i + (int) (Minecraft.getSystemTime() / 50)) % 8]).append(parString, i, i + 1);
+      outputString.append(colorChar[(i + Math.abs((int)Minecraft.getSystemTime()) / 50) % 8]).append(parString, i, i + 1);
     }
     return outputString.toString();
   }


### PR DESCRIPTION
Minecraft.getSystemTime() is a long and because it was being casted to
an int it would sometimes become negative. I'm not sure how this wasn't
a problem previously but throwing an abs() at it fixed the problem at
least.